### PR TITLE
Edit and delete actions for resources functional

### DIFF
--- a/NewEra/forms.py
+++ b/NewEra/forms.py
@@ -97,16 +97,18 @@ class RegistrationForm(forms.Form):
 class CreateResourceForm(forms.ModelForm):
 	name = forms.CharField(max_length=100, required=True)
 	description = forms.CharField(max_length=1000, widget=forms.Textarea(attrs=INPUT_ATTRIBUTES))
+	is_active = forms.BooleanField(required=False)
 	email = forms.EmailField(max_length=254, required=False)
 	phone = forms.CharField(max_length=10, required=False)
 	street = forms.CharField(max_length=100, required=False)
+	city = models.CharField(max_length=100)
 	zip_code = forms.CharField(max_length=10, required=False)
 	state = forms.CharField(max_length=2, required=False)
 	url = forms.URLField(required=False)
 
 	class Meta:
 		model = Resource
-		fields = ('name', 'description', 'start_date', 'end_date', 'email', 'phone', 'street', 'zip_code', 'state', 'image', 'url', 'tags')
+		fields = ('name', 'description', 'is_active', 'start_date', 'end_date', 'email', 'phone', 'street', 'zip_code', 'state', 'image', 'url', 'tags')
 		exclude = (
 			'content_type',
 		)

--- a/NewEra/templates/NewEra/delete_resource.html
+++ b/NewEra/templates/NewEra/delete_resource.html
@@ -1,0 +1,19 @@
+{% extends "NewEra/base.html" %}
+
+{% block title %}{% block navtitle %}
+	Delete Resource
+{% endblock %}{% endblock %}
+
+{% block content %}
+    <form method="POST" enctype="multipart/form-data" class="resource-form">
+        {% csrf_token %}
+        <h3 style="margin: auto; margin-top: 50px; text-align: center;">
+            Are you sure you want to delete {{ resource.name }}?
+        </h3>
+        <div style="margin: auto; margin-top: 50px; text-align: center;">
+            <p><u>WARNING</u>: The resource will be permanently deleted, unless it has been referred before, in which case it will be made inactive.</p>
+            <p><button class="btn btn-primary" type="submit">Delete</button>
+            <a href="javascript:history.back()" class="btn">Cancel</a></p>
+        </div>
+    </form>
+{% endblock %}

--- a/NewEra/templates/NewEra/edit_resource.html
+++ b/NewEra/templates/NewEra/edit_resource.html
@@ -1,19 +1,19 @@
 {% extends "NewEra/base.html" %}
 
 {% block title %}{% block navtitle %}
-	New Resource
+	Edit Resource
 {% endblock %}{% endblock %}
 
 {% block content %}
 	<h3 style="margin: auto; margin-top: 50px; text-align: center;">
-		New Resource
+		Edit Resource
 	</h3>
 
-    <form method="POST" enctype="multipart/form-data" action="{% url 'Create Resource' %}" class="resource-form">
+    <form method="POST" enctype="multipart/form-data" class="resource-form">
         {% csrf_token %}
         <table>
         	{{ form }}
         </table>
-        <button id="id_login_button" class="btn btn-primary" type="submit">Save Resource</button>
+        <button class="btn btn-primary" type="submit">Save Resource</button>
     </form>
 {% endblock %}

--- a/NewEra/templates/NewEra/get_resource.html
+++ b/NewEra/templates/NewEra/get_resource.html
@@ -23,11 +23,11 @@
             <p>{{ resource.description }}</p>
 
             <h3>Contact</h3>
-            <p><a href="{{r.url}}"><i class="material-icons">link</i>{{ resource.url }}</a></p>
+            <p><a href="{{resource.url}}"><i class="material-icons">link</i>{{ resource.url }}</a></p>
 
-            <p><a href="tel:{{r.phone}}"><i class="material-icons">phone</i>{{ resource.phone }}</a></p>
+            <p><a href="tel:{{resource.phone}}"><i class="material-icons">phone</i>{{ resource.phone }}</a></p>
 
-            <p><a href="mailto:{{r.email}}"><i class="material-icons">email</i>{{ resource.email }}</a></p>
+            <p><a href="mailto:{{resource.email}}"><i class="material-icons">email</i>{{ resource.email }}</a></p>
 
             <h3>Address</h3>
             <p><i class="material-icons">location_on</i>{{ resource.street }}, {{ resource.city }}, {{ resource.state }} {{ resource.zip_code }}</p>
@@ -40,11 +40,11 @@
         <br><hr></br>
 
         {% if perms.resource.edit_resource %}
-            <a href="#" class="btn btn-warning"><i class="material-icons">edit</i>Edit Resource</a>
+            <a href="{% url 'Edit Resource' resource.id %}" class="btn btn-warning"><i class="material-icons">edit</i>Edit</a>
         {% endif %}
 
         {% if perms.resource.delete_resource %}
-            <a href="#" class="btn btn-danger"><i class="material-icons">delete</i>Delete Resource</a>
+            <a href="{% url 'Delete Resource' resource.id %}" class="btn btn-danger"><i class="material-icons">delete</i>Delete</a>
         {% endif %}
 
     </div>

--- a/NewEra/templates/NewEra/resources.html
+++ b/NewEra/templates/NewEra/resources.html
@@ -8,9 +8,12 @@
 	<h3 style="margin: auto; margin-top: 50px; text-align: center;">
 		Resources
 	</h3>
-	{% if perms.resource.create_resource %}
-		<a href="{% url 'Create Resource' %}" class="btn btn-primary"><i class="material-icons">add</i>Add Resource</a>
-	{% endif %}
+
+	<div class="container">
+		{% if perms.resource.create_resource %}
+			<a href="{% url 'Create Resource' %}" class="btn btn-primary"><i class="material-icons">add</i>Add Resource</a>
+		{% endif %}
+	</div>
 	<p>&nbsp;</p>
 	{% if resources.count > 0 %}
 		<div class="container">
@@ -47,9 +50,18 @@
 									<p>&nbsp;</p>
 								{% endif %}
 								<br/>
-								{% if perms.resource.edit_resource %}
-									<a href="#" class="btn btn-warning"><i class="material-icons">edit</i>Edit Resource</a>
-								{% endif %}
+								<div class="row">
+									<div class="col">
+										{% if perms.resource.edit_resource %}
+											<a href="{% url 'Edit Resource' r.id %}" class="btn btn-warning"><i class="material-icons">edit</i>Edit</a>
+										{% endif %}
+									</div>
+									<div class="col">
+										{% if perms.resource.delete_resource %}
+									        <a href="{% url 'Delete Resource' r.id %}" class="btn btn-danger"><i class="material-icons">delete</i>Delete</a>
+									    {% endif %}
+									</div>
+								</div>
 							</div>
 						</div>
 					</div>

--- a/ReEntryApp/urls.py
+++ b/ReEntryApp/urls.py
@@ -37,4 +37,6 @@ urlpatterns = [
     # Routes for ADMINs 
     path('manage_users/', views.manage_users, name='Manage Users'),
     path('resources/new/', views.create_resource, name='Create Resource'),
+    path('resources/<int:id>/edit/', views.edit_resource, name='Edit Resource'),
+    path('resources/<int:id>/delete/', views.delete_resource, name='Delete Resource'),
 ]


### PR DESCRIPTION
- Resources can now be edited
  - City and active state are editable
  - Edit buttons now link to the appropriate page
  - Edit resource option does not include Tag support yet
  - Image cannot be edited or removed yet (also no styling/limit on image)
- Resources can be deleted
  - Delete buttons link appropriately
  - If a resource is used in a referral, it will only be made inactive, and not deleted (tested in console, as Referral doesn't have a creation action yet)
  - Deleting a resource on its detail page causes an error as the result of difficulty in redirecting