### PR TITLE
Export to Excel spreadsheet implementation

### DIFF
--- a/NewEra/models.py
+++ b/NewEra/models.py
@@ -60,9 +60,7 @@ class CaseLoadUser(models.Model):
 	last_name = models.CharField(max_length=35, blank=False, null=False)
 	# https://stackoverflow.com/questions/386294/what-is-the-maximum-length-of-a-valid-email-address
 	email = models.EmailField(max_length=254)
-	# 10 is the max length to force a phone number to be just the digits
-	# We can change this later if needed
-	phone = models.CharField(max_length=11) # NOTE: temporarily null=True so users can be added to caseload
+	phone = models.CharField(max_length=11)
 	notes = models.CharField(max_length=1000)
 	is_active = models.BooleanField(default=True)
 	user = models.ForeignKey(User, on_delete=models.PROTECT, blank=True, null=True)

--- a/NewEra/templates/NewEra/create_referral.html
+++ b/NewEra/templates/NewEra/create_referral.html
@@ -32,7 +32,7 @@
             <div class="tab-content" id="nav-tabContent">
                 <div class="tab-pane fade show active" id="nav-caseload" role="tabpanel" aria-labelledby="nav-caseload-tab">
                     <br/>
-                    {% if recipients.size > 0 %}
+                    {% if recipients.count > 0 %}
                         <form action="{% url 'Create Referral' %}" method="POST">
                             {% for r in resources %}
                                 <input type="hidden" name="resources[]" value="{{ r.id }}">

--- a/NewEra/templates/NewEra/index.html
+++ b/NewEra/templates/NewEra/index.html
@@ -16,6 +16,13 @@
 			Reintegrating previously incarcerated citizens into society.
 		</p>
 		<a href="{% url 'Resources' %}"><button type="button" class="btn btn-info">See Resources</button></a>
+		{% if perms.resource.create_resource %}
+			<br/>
+			<br/>
+			<div class="d-flex justify-content-center">
+				<a href="{% url 'Export Data' %}" class="btn btn-success"><i class="material-icons">get_app</i>Download Data Spreadsheet</a>
+			</div>
+		{% endif %}
 	</div>
 
 	<div class="secondary-content">

--- a/NewEra/templates/NewEra/resources.html
+++ b/NewEra/templates/NewEra/resources.html
@@ -10,6 +10,7 @@
 	</h1>
 
 	<div class="container">
+
 		<hr/>
 		<h3>Filter Resources</h3>
 		<form action="" method="get" class="tag-form">
@@ -63,7 +64,9 @@
 									{% else %}
 										<p>&nbsp;</p>
 									{% endif %}
-									<p>Views: {{ r.clicks }}</p>
+									{% if perms.resource.create_resource %}
+										<p>Views: {{ r.clicks }}</p>
+									{% endif %}
 									<br/>
 									<div class="row">
 										<div class="col">

--- a/ReEntryApp/urls.py
+++ b/ReEntryApp/urls.py
@@ -54,5 +54,7 @@ urlpatterns = [
     # Case load actions
     path('case_load/<int:id>', views.get_case_load_user, name='Show Case Load User'),
     path('case_load/<int:id>/edit/', views.edit_case_load_user, name='Edit Case Load User'),
-    path('case_load/<int:id>/delete/', views.delete_case_load_user, name='Delete Case Load User')
+    path('case_load/<int:id>/delete/', views.delete_case_load_user, name='Delete Case Load User'),
+    # Resource data export action
+    path('export', views.export_data, name='Export Data')
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ psycopg2==2.8.4
 pytz==2019.3
 sqlparse==0.3.0
 whitenoise==5.0.1
+openpyxl==3.0.3


### PR DESCRIPTION
**This will require installation of openpyxl, specifically v3.0.3. Running `pip install openpyxl` should do it.**

- "Download Data Spreadsheet" button now on index page for admins only
  - Downloads an Excel with four sheets detailing referrals by resource, tag, user, and phone number referred
  - Method (very long) is in views.py, url created in urls.py
  - NOTE: This has only been tested locally; it should work when deployed, but at present it hasn't been tested that way.
- Referrals for CaseLoadUser now set the phone and email of the CaseLoadUser when the referral is made (changed in urls.py)
- Bug with CaseLoadUser loading spotted and fixed ("size" replaced with "count")
- Viewing resource clicks are now admin-only