### PR TITLE
Change password and reset password implemented, in addition to minor UI changes

### DIFF
--- a/NewEra/static/NewEra/referrals.js
+++ b/NewEra/static/NewEra/referrals.js
@@ -8,7 +8,7 @@ $(document).ready(function() {
     # 
     $('#make-referral').attr('state', 'off');
     $('#make-referral').click(toggleSelect);
-    $('#referral-ins').css('display', 'none');
+    // $('#referral-ins').css('display', 'none');
 
     // Validation to require ONE of: { phone, email }
     $('#outOfSystemForm').on('submit', function(e){

--- a/NewEra/templates/NewEra/_navbar.html
+++ b/NewEra/templates/NewEra/_navbar.html
@@ -47,6 +47,13 @@
               </li>
             {% endif %}
 
+            {% if user.is_staff %}
+              <li class="nav-item">
+                {% url 'password_change' as change_password %}
+                <a class="nav-link {% if request.path == manage_users_url %}active{% endif %}" href="{{ change_password }}">Change Password</a>
+              </li>
+            {% endif %}
+
             {% if user.is_authenticated %}
               <li class="nav-item">
                 <a class="nav-link" href="{% url 'Logout' %}">Log Out</a>

--- a/NewEra/templates/NewEra/edit_user.html
+++ b/NewEra/templates/NewEra/edit_user.html
@@ -5,7 +5,7 @@
 {% endblock %}{% endblock %}
 
 {% block content %}
-    <div class="container ">
+    <div class="container">
         <div class="row">
             <div class="col">
  

--- a/NewEra/templates/NewEra/login.html
+++ b/NewEra/templates/NewEra/login.html
@@ -16,5 +16,7 @@
             <hr/>
             <button id="id_login_button" class="btn btn-primary" type="submit">Log In</button>
         </form>
+        <br/>
+        <p><a href="{% url 'reset_password' %}"><u>Forgot your password?</u></a></p>
     </div>
 {% endblock %}

--- a/NewEra/templates/NewEra/password_change.html
+++ b/NewEra/templates/NewEra/password_change.html
@@ -1,0 +1,38 @@
+{% extends "NewEra/base.html" %}
+
+{% block page_specific_styles %}{% endblock %}
+
+{% block title %}
+	Change Password 
+{% endblock %}
+
+{% block content %}
+	<div class="container">
+        <div class="row">
+            <div class="col">
+ 
+	            <h3 style="margin: auto; margin-top: 50px; text-align: center;">
+	                Change Password
+	            </h3>
+	            <br/>
+
+	            <form method="POST" enctype="multipart/form-data" class="resource-form">
+	                {% csrf_token %}
+	                <input name="old_password" class="form-control" placeholder="Old password" type="password" id="id_old_password" required/>
+	                <input name="new_password1" class="form-control" placeholder="New password" type="password" id="id_new_password1" required/>
+	                <input name="new_password2" class="form-control" placeholder="Confirm password" type="password" id="id_new_password2" required/>
+
+	                {% for field in form %}
+	                	{% for error in field.errors %}
+	                		<p style="color: red">{{ error }}</p>
+	                	{% endfor %}
+	                {% endfor %}
+
+	                <br/>
+	                <button class="btn btn-primary" type="submit">Change Password</button>
+	            </form>
+
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/NewEra/templates/NewEra/password_change_done.html
+++ b/NewEra/templates/NewEra/password_change_done.html
@@ -1,0 +1,24 @@
+{% extends "NewEra/base.html" %}
+
+{% block page_specific_styles %}{% endblock %}
+
+{% block title %}
+	Change Password Done
+{% endblock %}
+
+{% block content %}
+	<div class="container">
+        <div class="row">
+            <div class="col">
+ 
+	            <h3 style="margin: auto; margin-top: 50px; text-align: center;">
+	                Change Password
+	            </h3>
+	            <br/>
+
+	            <p style="margin: auto; text-align: center;">Your password has been changed.</p>
+
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/NewEra/templates/NewEra/password_reset.html
+++ b/NewEra/templates/NewEra/password_reset.html
@@ -1,0 +1,37 @@
+{% extends "NewEra/base.html" %}
+
+{% block page_specific_styles %}{% endblock %}
+
+{% block title %}
+	Reset Password 
+{% endblock %}
+
+{% block content %}
+	<div class="container">
+        <div class="row">
+            <div class="col">
+ 
+	            <h3 style="margin: auto; margin-top: 50px; text-align: center;">
+	                Reset Password
+	            </h3>
+	            <br/>
+
+	            {% if request.user.is_authenticated == False %}
+		            <p style="margin: auto; text-align: center;">Enter your email address below and you'll receive an email with instructions to reset your password.</p>
+		            <br/>
+
+		            <form method="POST" enctype="multipart/form-data" class="resource-form">
+		                {% csrf_token %}
+		                <table>
+		                    {{ form }}
+		                </table>
+		                <br/>
+		                <button class="btn btn-primary" type="submit">Send Password Reset Email</button>
+		            </form>
+		        {% else %}
+		        	<p style="margin: auto; text-align: center;">You are already logged in. To reset your password, please log out.</p>
+		        {% endif %}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/NewEra/templates/NewEra/password_reset_complete.html
+++ b/NewEra/templates/NewEra/password_reset_complete.html
@@ -1,0 +1,24 @@
+{% extends "NewEra/base.html" %}
+
+{% block page_specific_styles %}{% endblock %}
+
+{% block title %}
+	Reset Password Complete
+{% endblock %}
+
+{% block content %}
+	<div class="container">
+        <div class="row">
+            <div class="col">
+ 
+	            <h3 style="margin: auto; margin-top: 50px; text-align: center;">
+	                Reset Password
+	            </h3>
+	            <br/>
+
+	            <p style="margin: auto; text-align: center;">Your password has been reset.</p>
+
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/NewEra/templates/NewEra/password_reset_done.html
+++ b/NewEra/templates/NewEra/password_reset_done.html
@@ -1,0 +1,24 @@
+{% extends "NewEra/base.html" %}
+
+{% block page_specific_styles %}{% endblock %}
+
+{% block title %}
+	Reset Password Done
+{% endblock %}
+
+{% block content %}
+	<div class="container">
+        <div class="row">
+            <div class="col">
+ 
+	            <h3 style="margin: auto; margin-top: 50px; text-align: center;">
+	                Reset Password
+	            </h3>
+	            <br/>
+
+	            <p style="margin: auto; text-align: center;">Instructions for resetting your password have been sent to your email address. If you don't see the email, please check your spam folder.</p>
+
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/NewEra/templates/NewEra/password_reset_form.html
+++ b/NewEra/templates/NewEra/password_reset_form.html
@@ -1,0 +1,37 @@
+{% extends "NewEra/base.html" %}
+
+{% block page_specific_styles %}{% endblock %}
+
+{% block title %}
+	Reset Password 
+{% endblock %}
+
+{% block content %}
+	<div class="container">
+        <div class="row">
+            <div class="col">
+ 
+	            <h3 style="margin: auto; margin-top: 50px; text-align: center;">
+	                Reset Password
+	            </h3>
+	            <br/>
+
+	            {% if request.user.is_authenticated == False %}
+		            <p style="margin: auto; text-align: center;">Please enter your new password twice, so we can verify you typed it in correctly.</p>
+		            <br/>
+
+		            <form method="POST" enctype="multipart/form-data" class="resource-form">
+		                {% csrf_token %}
+		                <table>
+		                    {{ form }}
+		                </table>
+		                <br/>
+		                <button class="btn btn-primary" type="submit">Reset Password</button>
+		            </form>
+		        {% else %}
+		        	<p style="margin: auto; text-align: center;">You are already logged in. To reset your password, please log out.</p>
+		        {% endif %}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/NewEra/templates/NewEra/referrals.html
+++ b/NewEra/templates/NewEra/referrals.html
@@ -101,6 +101,7 @@
         {% endif %}
 
         <br/>
-        <p>If you want to create a referral, go to the resources page and start a referral.</p>
+        <p>To create a referral, go to the resources page and click "Make Referral".</p>
+        <br/>
     </div>
 {% endblock %}

--- a/NewEra/templates/NewEra/resources.html
+++ b/NewEra/templates/NewEra/resources.html
@@ -12,7 +12,11 @@
 		Resources
 	</h1>
 
-    <p id="referral-ins" style="margin: auto; text-align: center;">Click the resources to select the resources for your referral and they will highlight green.</p>
+	{% if request.user.is_authenticated %}
+    	<p id="referral-ins" style="margin: auto; text-align: center;">Click the resources to select the resources for your referral and they will highlight green.</p>
+    {% else %}
+    	<p></p>
+    {% endif %}
 
 	<div class="container">
 		<hr/>

--- a/ReEntryApp/urls.py
+++ b/ReEntryApp/urls.py
@@ -14,6 +14,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
+from django.contrib.auth import views as auth_views
 from django.urls import path
 from NewEra import views
 
@@ -58,5 +59,16 @@ urlpatterns = [
     path('case_load/<int:id>/delete/', views.delete_case_load_user, name='Delete Case Load User'),
     # Resource data export action
     path('export', views.export_data, name='Export Data'),
-    path('resetViews', views.resetViews, name='Reset Views')
+    path('resetViews', views.resetViews, name='Reset Views'),
+    # https://www.youtube.com/watch?v=qjlZWBbX7-o
+    # https://www.youtube.com/watch?v=sFPcd6myZrY
+    # Password change
+    path('change_password/', auth_views.PasswordChangeView.as_view(template_name='NewEra/password_change.html'), name='password_change'),
+    path('change_password/done/', auth_views.PasswordChangeDoneView.as_view(template_name='NewEra/password_change_done.html'), name='password_change_done'),
+    # path('change_password/complete/', auth_views.PasswordChangeCompleteView.as_view(template_name='NewEra/password_change_complete.html'), name='password_change_complete'),
+    # Password reset
+    path('reset_password/', auth_views.PasswordResetView.as_view(template_name='NewEra/password_reset.html'), name='reset_password'),
+    path('reset_password/done/', auth_views.PasswordResetDoneView.as_view(template_name='NewEra/password_reset_done.html'), name='password_reset_done'),
+    path('reset/<uidb64>/<token>/', auth_views.PasswordResetConfirmView.as_view(template_name='NewEra/password_reset_form.html'), name='password_reset_confirm'),
+    path('reset_password/complete/', auth_views.PasswordResetCompleteView.as_view(template_name='NewEra/password_reset_complete.html'), name='password_reset_complete'),
 ]


### PR DESCRIPTION
Logged in users can change their password via a link on the navbar, and reset their passwords via email if they don't remember what it is, as long as they aren't logged in. Minor styling tweaks also implemented, so there are no longer instructions for referrals if the user is not logged in.